### PR TITLE
Fix "restore to previous"

### DIFF
--- a/src/main/java/com/madgag/gif/fmsware/GifDecoder.java
+++ b/src/main/java/com/madgag/gif/fmsware/GifDecoder.java
@@ -75,6 +75,7 @@ public class GifDecoder {
 	protected Rectangle lastRect; // last image rect
 	protected BufferedImage image; // current frame
 	protected BufferedImage lastImage; // previous frame
+	protected BufferedImage restorePrevImage; // for restore to previous
 
 	protected byte[] block = new byte[256]; // current data block
 	protected int blockSize = 0; // block size
@@ -162,13 +163,7 @@ public class GifDecoder {
 		// fill in starting image contents based on last image's dispose code
 		if (lastDispose > 0) {
 			if (lastDispose == 3) {
-				// use image before last
-				int n = frameCount - 2;
-				if (n > 0) {
-					lastImage = getFrame(n - 1);
-				} else {
-					lastImage = null;
-				}
+				lastImage = restorePrevImage;
 			}
 
 			if (lastImage != null) {
@@ -192,6 +187,15 @@ public class GifDecoder {
 					g.dispose();
 				}
 			}
+		}
+
+		// copy before drawing for restore to previous
+		if (dispose == 3) {
+			if (restorePrevImage == null) {
+				restorePrevImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB_PRE);
+			}
+			int[] restore = ((DataBufferInt) restorePrevImage.getRaster().getDataBuffer()).getData();
+			System.arraycopy(dest, 0, restore, 0, width * height);
 		}
 
 		// copy each source line to the appropriate place in the destination


### PR DESCRIPTION
The disposal method "restore to previous" should restore to what was there before the graphic is drawn, so to the image data after the disposal of the previous frame, not to the previous frame. This disposal method isn't used very often, but I've encountered a few GIFs where it is an issue. A few examples are on [this page](http://www.imagemagick.org/Usage/anim_basics/#cleared).

The [GIF Spec](https://www.w3.org/Graphics/GIF/spec-gif89a.txt) says:

> 3 -   Restore to previous. The decoder is required to
                              restore the area overwritten by the graphic with
                              what was there prior to rendering the graphic.

Which I didn't quite know how to interpret exactly (and there do seem to be different interpretations on some websites that explain how it's supposed to work), but based on the GIFs I encountered and how modern browsers handle them, this fix should be correct.

## Example

![bunny](https://user-images.githubusercontent.com/5621113/53643259-e8e79300-3c33-11e9-81bc-f3d7876636c2.gif)

Following are screenshots of the individual frames of this GIF (top row the finished frame, bottom row what each frame adds).

Original:
![gifdecoder_unfixed](https://user-images.githubusercontent.com/5621113/53643098-7c6c9400-3c33-11e9-84e0-e4b5d258b0c9.jpg)

Fixed:
![gifdecoder_fixed](https://user-images.githubusercontent.com/5621113/53643097-7c6c9400-3c33-11e9-88d4-14f53ef2d76d.jpg)

----

This change is my own work and while I'm not convinced I can legally disclaim or transfer copyright, you can see this change as being under [CC0](https://creativecommons.org/publicdomain/zero/1.0/), so effectively Public Domain.