### PR TITLE
Set an automatic module name in the Jar MANIFEST, closes #13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,18 @@
                     <target>1.6</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.madgag.gif.fmsware</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Add an entry to the Maven POM so an automatic module name is set in the Jar manifest.

- This PR was tested:  I verified that the resulting Jar file does contain the module name.

- The code in this PR is public domain.